### PR TITLE
BE-318: Initiate subscribe genesis correctly

### DIFF
--- a/x/subscribe/abci.go
+++ b/x/subscribe/abci.go
@@ -42,7 +42,7 @@ func getValidatorSnapshotKeys(ctx sdk.Context, keeper Keeper) [][]byte {
 	var snapshotKeys [][]byte
 	validators := keeper.validatorKeeper.GetValidators(ctx)
 	for _, validator := range validators {
-		ethAddr := validator.Description.Moniker
+		ethAddr := validator.Description.Identity
 		candidate := keeper.validatorKeeper.GetCandidate(ctx, ethAddr)
 		snapshotKeys = append(snapshotKeys, candidate.GetSnapshotKey())
 	}

--- a/x/subscribe/alias.go
+++ b/x/subscribe/alias.go
@@ -31,8 +31,9 @@ var (
 	GetRequestKey              = types.GetRequestKey
 	GetEpochKey                = types.GetEpochKey
 	GetLatestEpochKey          = types.GetLatestEpochKey
-	SubscriptionKeyPrefix            = types.SubscriptionKeyPrefix
+	SubscriptionKeyPrefix      = types.SubscriptionKeyPrefix
 	CLIQueryRequest            = cli.QueryRequest
+	DefaultParams              = types.DefaultParams
 )
 
 type (
@@ -42,6 +43,7 @@ type (
 	Subscription            = types.Subscription
 	Request                 = types.Request
 	Epoch                   = types.Epoch
+	Params                  = types.Params
 	QuerySubscriptionParams = types.QuerySubscriptionParams
 	QueryRequestParams      = types.QueryRequestParams
 	QueryEpochParams        = types.QueryEpochParams

--- a/x/subscribe/genesis.go
+++ b/x/subscribe/genesis.go
@@ -6,24 +6,30 @@ import (
 )
 
 type GenesisState struct {
+	Params Params `json:"params" yaml:"params"`
 }
 
-func NewGenesisState() GenesisState {
-	return GenesisState{}
+func NewGenesisState(params Params) GenesisState {
+	return GenesisState{
+		Params: params,
+	}
 }
 
 func ValidateGenesis(data GenesisState) error {
-	return nil
+	return data.Params.Validate()
 }
 
 func DefaultGenesisState() GenesisState {
-	return GenesisState{}
+	return NewGenesisState(DefaultParams())
 }
 
 func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) []abci.ValidatorUpdate {
+	keeper.SetParams(ctx, data.Params)
+
 	return []abci.ValidatorUpdate{}
 }
 
-func ExportGenesis(ctx sdk.Context, k Keeper) GenesisState {
-	return GenesisState{}
+func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
+	params := keeper.GetParams(ctx)
+	return NewGenesisState(params)
 }

--- a/x/subscribe/types/params.go
+++ b/x/subscribe/types/params.go
@@ -28,8 +28,8 @@ var _ params.ParamSet = (*Params)(nil)
 
 // Params defines the high level settings for subscribe
 type Params struct {
-	EpochLength  int64   `json:"maxValidators" yaml:"maxValidators"` // epoch length based on seconds
-	CostPerEpoch sdk.Int `json:"costPerEpoch" yaml:"costPerEpoch"`   // The fee will be charged for subscription per epoch
+	EpochLength  int64   `json:"epochLength" yaml:"epochLength"`   // epoch length based on seconds
+	CostPerEpoch sdk.Int `json:"costPerEpoch" yaml:"costPerEpoch"` // The fee will be charged for subscription per epoch
 }
 
 // NewParams creates a new Params instance

--- a/x/validator/handler.go
+++ b/x/validator/handler.go
@@ -72,7 +72,8 @@ func handleMsgClaimValidator(ctx sdk.Context, keeper Keeper, msg MsgClaimValidat
 
 	if !found {
 		description := staking.Description{
-			Moniker: msg.EthAddress,
+			Moniker:  msg.EthAddress,
+			Identity: msg.EthAddress,
 		}
 		validator = staking.NewValidator(valAddress, pk, description)
 		validator.Status = sdk.Bonded


### PR DESCRIPTION
Currently, the parameters cannot be written into or read from genesis file. Need to configure genesis correctly, so the node can correctly export and read genesis file. 