### PR TITLE
BE-412: gateway api for query info

### DIFF
--- a/gateway/query.go
+++ b/gateway/query.go
@@ -5,13 +5,31 @@ import (
 	"net/http"
 
 	"github.com/celer-network/sgn/x/global"
+	"github.com/celer-network/sgn/x/subscribe"
 	"github.com/cosmos/cosmos-sdk/types/rest"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/gorilla/mux"
 )
 
 func (rs *RestServer) registerQueryRoutes() {
 	rs.Mux.HandleFunc(
 		"/global/latestBlock",
 		latestBlockHandlerFn(rs),
+	).Methods("GET")
+
+	rs.Mux.HandleFunc(
+		"/subscribe/params",
+		subscribeParamsHandlerFn(rs),
+	).Methods("GET")
+
+	rs.Mux.HandleFunc(
+		"/subscribe/subscription/{ethAddr}",
+		subscriptionHandlerFn(rs),
+	).Methods("GET")
+
+	rs.Mux.HandleFunc(
+		"/subscribe/request/{channelId}",
+		guardRequestHandlerFn(rs),
 	).Methods("GET")
 }
 
@@ -26,5 +44,49 @@ func latestBlockHandlerFn(rs *RestServer) http.HandlerFunc {
 		}
 
 		rest.PostProcessResponse(w, rs.transactor.CliCtx, res)
+	}
+}
+
+// http request handler to query subscribe params
+func subscribeParamsHandlerFn(rs *RestServer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		route := fmt.Sprintf("custom/%s/%s", subscribe.ModuleName, subscribe.QueryParameters)
+		res, _, err := rs.transactor.CliCtx.Query(route)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, rs.transactor.CliCtx, res)
+	}
+}
+
+// http request handler to query subscription
+func subscriptionHandlerFn(rs *RestServer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		ethAddr := vars["ethAddr"]
+		subscription, err := subscribe.CLIQuerySubscription(rs.transactor.CliCtx.Codec, rs.transactor.CliCtx, subscribe.RouterKey, ethAddr)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, rs.transactor.CliCtx, subscription)
+	}
+}
+
+// http request handler to query guard request
+func guardRequestHandlerFn(rs *RestServer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		channelId := ethcommon.Hex2Bytes(vars["channelId"])
+		request, err := subscribe.CLIQueryRequest(rs.transactor.CliCtx.Codec, rs.transactor.CliCtx, subscribe.RouterKey, channelId)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, rs.transactor.CliCtx, request)
 	}
 }

--- a/x/subscribe/alias.go
+++ b/x/subscribe/alias.go
@@ -28,6 +28,7 @@ var (
 	GetRequestKey              = types.GetRequestKey
 	SubscriptionKeyPrefix      = types.SubscriptionKeyPrefix
 	RequestGuardIdKey          = types.RequestGuardIdKey
+	CLIQuerySubscription       = cli.QuerySubscription
 	CLIQueryRequest            = cli.QueryRequest
 	DefaultParams              = types.DefaultParams
 )


### PR DESCRIPTION
Clients and OSP nodes are not expected to be 

API to query for state guarding SLA pricing (SLA specification described later)

API to query a certain address’s SLA level

API to query state stored in SGN

API to check if a state is settled correctly or not

