### PR TITLE
BE-468: fix error in handleMsgClaimValidator

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "operator": "cosmos1ddvpnk98da5hgzz8lf5y82gnsrhvu3jd3cukpp",
     "transactors": ["cosmos104gnaehlj7a32r9l5za7nhf463yvgnyfnwh9sc"],
     "passphrase": "12341234",
-    "pubkey": "cosmosvalconspub1zcjduepq7xxfahzlg82vfs90q2m6zrdjvwg2rlsd24eq8a73qw9aczl5yjyswgfv6h",
+    "pubkey": "cosmosvalconspub1zcjduepqmnz2m5asxrqplfl52lm2meq8fq3hc562ljmc6lqawr6kzsmw2g3snvmrdy",
     "chainID": "sgnchain",
     "nodeURI": "tcp://localhost:26657",
     "gasPrice": ""


### PR DESCRIPTION
public key is not right in config.json