### PR TITLE
BE-469: improve sidechain event monitoring

### DIFF
--- a/monitor/key.go
+++ b/monitor/key.go
@@ -32,7 +32,7 @@ func GetPusherKey(log types.Log) []byte {
 	return append(PusherKeyPrefix, log.TxHash.Bytes()...)
 }
 
-// get penalty key from nounce
+// get penalty key from nonce
 func GetPenaltyKey(nonce uint64) []byte {
 	return append(PenaltyKeyPrefix, sdk.Uint64ToBigEndian(nonce)...)
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -225,12 +225,12 @@ func (m *EthMonitor) monitorTendermintEvent(eventTag string, handleEvent func(ev
 	var err error
 
 	for {
-		er := m.db.Get(GetSgnEventKey(eventTag))
-		isInitialLaunch := len(er) == 0
+		eventRecordedRaw := m.db.Get(GetSgnEventKey(eventTag))
+		isInitialLaunch := len(eventRecordedRaw) == 0
 		eventRecorded := 0
 		initPage := 1
 		if !isInitialLaunch {
-			eventRecorded = int(binary.BigEndian.Uint64(er))
+			eventRecorded = int(binary.BigEndian.Uint64(eventRecordedRaw))
 			initPage = eventRecorded/txsPageLimit + 1
 		}
 		page := initPage


### PR DESCRIPTION
use kv store instead of bigcache to remember last seen event hash or block height

new sidechain node does not need to process previous events