### PR TITLE
Fix sync block

### DIFF
--- a/monitor/handler.go
+++ b/monitor/handler.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"math/big"
 	"time"
 
 	"github.com/celer-network/goutils/log"
@@ -39,8 +40,8 @@ func (m *EthMonitor) processEventQueue(secureBlockNum uint64) {
 	}
 }
 
-func (m *EthMonitor) handleNewBlock() {
-	log.Infoln("Catch new mainchain block", m.blkNum)
+func (m *EthMonitor) handleNewBlock(blkNum *big.Int) {
+	log.Infoln("Catch new mainchain block", blkNum)
 	if !m.isPuller() {
 		return
 	}
@@ -53,8 +54,8 @@ func (m *EthMonitor) handleNewBlock() {
 
 	time.Sleep(time.Duration(viper.GetInt64(common.FlagSgnTimeoutCommit)+params.BlkTimeDiffLower) * time.Second)
 
-	log.Infof("Add MsgSyncBlock %d to transactor msgQueue", m.blkNum)
-	msg := global.NewMsgSyncBlock(m.blkNum.Uint64(), m.blockSyncer.Key.GetAddress())
+	log.Infof("Add MsgSyncBlock %d to transactor msgQueue", blkNum)
+	msg := global.NewMsgSyncBlock(blkNum.Uint64(), m.blockSyncer.Key.GetAddress())
 	m.blockSyncer.AddTxMsg(msg)
 }
 

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -120,7 +120,7 @@ func (m *EthMonitor) monitorBlockHead() {
 		}
 
 		m.blkNum = blkNum
-		go m.handleNewBlock()
+		go m.handleNewBlock(blkNum)
 	}
 }
 


### PR DESCRIPTION
Currently sync block will have high failure when mainchain block interval is smaller than sidechain block interval. Instead of using `m.blkNum`, we need to pass `blkNum` to the `handleNewBlock` 