### PR TITLE
Add build-linux as a dependency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ build-dockers:
 
 # Prepare docker environment for multinode testing
 .PHONY: prepare-docker-env
-prepare-docker-env: build-dockers prepare-geth-data
+prepare-docker-env: build-dockers build-linux prepare-geth-data
 
 # Run geth
 .PHONY: localnet-start-geth


### PR DESCRIPTION
prepare-docker-env should also update sgncli, which is built with
build-linux.