### PR TITLE
Fix multinode listen address in config.toml

### DIFF
--- a/test/multi-node-data/node1/sgnd/config/config.toml
+++ b/test/multi-node-data/node1/sgnd/config/config.toml
@@ -81,7 +81,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://127.0.0.1:26657"
+laddr = "tcp://0.0.0.0:26657"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support

--- a/test/multi-node-data/node2/sgnd/config/config.toml
+++ b/test/multi-node-data/node2/sgnd/config/config.toml
@@ -81,7 +81,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://127.0.0.1:26657"
+laddr = "tcp://0.0.0.0:26657"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support


### PR DESCRIPTION
Needed for executing queries from outside the containers.